### PR TITLE
feature/pointerLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ features = [
     'MouseEvent',
     'WheelEvent',
     'Performance',
-    'FocusEvent',
 
     # WebGL stuff
     'WebGl2RenderingContext',

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,15 +159,6 @@ pub fn main() -> Result<(), JsValue>
             elem.dyn_into::<HtmlCanvasElement>()?
         };
 
-    {
-        let canvas_clone = canvas.clone();
-        let callback = move |_event: web_sys::FocusEvent|
-            {
-                canvas_clone.request_pointer_lock();
-            };
-        let ev = EventListener::new(&canvas, "focus", callback).expect("pointer lock event listener");
-        ev.forget();
-    }
     let context = new_context(&canvas)?;
 
     context.enable(Context::CULL_FACE);
@@ -302,10 +293,12 @@ pub fn main() -> Result<(), JsValue>
 
     {
         clone!(camera);
+        let canvas_clone = canvas.clone();
         let callback = move |event: web_sys::MouseEvent|
             {
                 if event.buttons() == 1
                 {
+                    canvas_clone.request_pointer_lock();
                     borrow_mut!(camera);
                     if event.movement_x() != 0
                     {


### PR DESCRIPTION
moved pointer lock request to the mousemove listener where camera movement happens. Lock is requested when you click and begin to move the camera (click + drag)