### PR TITLE
Feature/wasm tests

### DIFF
--- a/src/gfx/gl_object/buffer.rs
+++ b/src/gfx/gl_object/buffer.rs
@@ -21,7 +21,7 @@ pub trait Buffer : crate::gfx::gl_object::traits::GlObject
     fn bind_range(&mut self, index: u32, offset: i32, size: i32);
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Hash)]
 pub struct RangeBinding(pub u32, pub i32, pub i32);
 
 /// Implements the buffer trait for either a pre-existing struct or
@@ -211,7 +211,7 @@ mod tests
         gl_object::
         {
             traits::Bindable,
-            buffer::Buffer,
+            buffer::{Buffer, RangeBinding},
             ArrayBuffer,
         },
     };
@@ -239,10 +239,20 @@ mod tests
 
         let mut buff: [u8; 4] = [0, 1, 2, 3];
         buffer.buffer_data(&buff, Context::STATIC_DRAW);
-        assert_eq!(&buffer.buffer, &buff);
+        assert_eq!(&buff, buffer.buffer.as_slice());
 
         buff[1] = 4;
-        buffer.buffer_sub_data(1, &[4]);
-        assert_eq!(&buffer.buffer, &buff);
+        buffer.buffer_sub_data(1, &[4u8]);
+        assert_eq!(&buff, buffer.buffer.as_slice());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_range_bindings()
+    {
+        let context = get_context();
+        let mut buffer = ArrayBuffer::new(&context).expect("array buffer");
+        buffer.bind_range(0, 0, 1);
+
+        assert_eq!(Some(RangeBinding(0, 0, 1)), buffer.range_bindings[0]);
     }
 }

--- a/src/gfx/gl_object/buffer.rs
+++ b/src/gfx/gl_object/buffer.rs
@@ -215,6 +215,7 @@ mod tests
     {
         let context = get_context();
         let mut buffer = ArrayBuffer::new(&context).expect("array buffer");
+        buffer.bind_internal();
         assert_eq!(GfxError::GlErrors(vec![GlError::NoError]), gl_get_errors(&context));
 
         let mut buff: [u8; 4] = [0, 1, 2, 3];
@@ -223,7 +224,7 @@ mod tests
 
         // TODO: This fails, is it because of the testing environment or
         //  is there actually a bug somewhere?
-        //assert_eq!(GfxError::GlErrors(vec![GlError::NoError]), gl_get_errors(&context));
+        assert_eq!(GfxError::GlErrors(vec![GlError::NoError]), gl_get_errors(&context));
 
         buff[1] = 4;
         buffer.buffer_sub_data(1, &[4u8]);
@@ -235,6 +236,7 @@ mod tests
     {
         let context = get_context();
         let mut buffer = ArrayBuffer::new(&context).expect("array buffer");
+        buffer.bind_internal();
         buffer.bind_range(0, 0, 1);
 
         assert_eq!(Some(RangeBinding(0, 0, 1)), buffer.range_bindings[0]);

--- a/src/gfx/gl_object/buffer.rs
+++ b/src/gfx/gl_object/buffer.rs
@@ -237,8 +237,12 @@ mod tests
         let context = get_context();
         let mut buffer = ArrayBuffer::new(&context).expect("array buffer");
 
-        let buff: [u8; 4] = [0, 1, 2, 3];
+        let mut buff: [u8; 4] = [0, 1, 2, 3];
         buffer.buffer_data(&buff, Context::STATIC_DRAW);
+        assert_eq!(&buffer.buffer, &buff);
 
+        buff[1] = 4;
+        buffer.buffer_sub_data(1, &[4]);
+        assert_eq!(&buffer.buffer, &buff);
     }
 }

--- a/src/gfx/gl_object/buffer.rs
+++ b/src/gfx/gl_object/buffer.rs
@@ -193,3 +193,49 @@ macro_rules! impl_buffer
             }
     };
 }
+
+#[cfg(test)]
+mod tests
+{
+    use wasm_bindgen_test::*;
+    wasm_bindgen_test_configure!(run_in_browser);
+    use wasm_bindgen::
+    {
+        prelude::*,
+        JsCast,
+    };
+    use web_sys::*;
+    use crate::gfx::
+    {
+        Context,
+        gl_object::
+        {
+            traits::Bindable,
+            buffer::Buffer,
+            ArrayBuffer,
+        },
+    };
+
+    fn get_context() -> Context
+    {
+        let window: Window = window().expect("window context");
+        let document: Document = window.document().expect("document context");
+
+        let canvas =
+            {
+                //let elem = document.get_element_by_id("canvas").expect("canvas handle");
+                let elem = document.create_element("CANVAS").expect("new canvas element");
+                elem.set_id("canvas");
+                document.body().expect("document body").append_child(&elem).expect("canvas added to body");
+                elem.dyn_into::<HtmlCanvasElement>().expect("cast canvas element")
+            };
+        crate::gfx::new_context(&canvas).expect("context")
+    }
+
+    #[wasm_bindgen_test]
+    fn test_buffer_contents()
+    {
+        let context = get_context();
+        let buffer = ArrayBuffer::new(&context);
+    }
+}

--- a/src/gfx/gl_object/buffer.rs
+++ b/src/gfx/gl_object/buffer.rs
@@ -194,23 +194,14 @@ macro_rules! impl_buffer
     };
 }
 
+
 #[cfg(test)]
 mod tests
 {
-    use wasm_bindgen_test::*;
-    wasm_bindgen_test_configure!(run_in_browser);
-    use wasm_bindgen::
-    {
-        prelude::*,
-        JsCast,
-    };
-    use web_sys::*;
+    inject_wasm_test_boilerplate!();
+
     use crate::gfx::
     {
-        Context,
-        GfxError,
-        GlError,
-        gl_get_errors,
         gl_object::
         {
             traits::Bindable,
@@ -218,21 +209,6 @@ mod tests
             ArrayBuffer,
         },
     };
-
-    fn get_context() -> Context
-    {
-        let window: Window = window().expect("window context");
-        let document: Document = window.document().expect("document context");
-
-        let canvas =
-            {
-                let elem = document.create_element("CANVAS").expect("new canvas element");
-                elem.set_id("canvas");
-                document.body().expect("document body").append_child(&elem).expect("canvas added to body");
-                elem.dyn_into::<HtmlCanvasElement>().expect("cast canvas element")
-            };
-        crate::gfx::new_context(&canvas).expect("context")
-    }
 
     #[wasm_bindgen_test]
     fn test_buffer_data()

--- a/src/gfx/gl_object/buffer.rs
+++ b/src/gfx/gl_object/buffer.rs
@@ -235,6 +235,10 @@ mod tests
     fn test_buffer_contents()
     {
         let context = get_context();
-        let buffer = ArrayBuffer::new(&context);
+        let mut buffer = ArrayBuffer::new(&context).expect("array buffer");
+
+        let buff: [u8; 4] = [0, 1, 2, 3];
+        buffer.buffer_data(&buff, Context::STATIC_DRAW);
+
     }
 }

--- a/src/gfx/gl_object/buffer.rs
+++ b/src/gfx/gl_object/buffer.rs
@@ -223,7 +223,6 @@ mod tests
 
         let canvas =
             {
-                //let elem = document.get_element_by_id("canvas").expect("canvas handle");
                 let elem = document.create_element("CANVAS").expect("new canvas element");
                 elem.set_id("canvas");
                 document.body().expect("document body").append_child(&elem).expect("canvas added to body");

--- a/src/gfx/gl_object/buffer.rs
+++ b/src/gfx/gl_object/buffer.rs
@@ -208,6 +208,9 @@ mod tests
     use crate::gfx::
     {
         Context,
+        GfxError,
+        GlError,
+        gl_get_errors,
         gl_object::
         {
             traits::Bindable,
@@ -232,14 +235,19 @@ mod tests
     }
 
     #[wasm_bindgen_test]
-    fn test_buffer_contents()
+    fn test_buffer_data()
     {
         let context = get_context();
         let mut buffer = ArrayBuffer::new(&context).expect("array buffer");
+        assert_eq!(GfxError::GlErrors(vec![GlError::NoError]), gl_get_errors(&context));
 
         let mut buff: [u8; 4] = [0, 1, 2, 3];
         buffer.buffer_data(&buff, Context::STATIC_DRAW);
         assert_eq!(&buff, buffer.buffer.as_slice());
+
+        // TODO: This fails, is it because of the testing environment or
+        //  is there actually a bug somewhere?
+        //assert_eq!(GfxError::GlErrors(vec![GlError::NoError]), gl_get_errors(&context));
 
         buff[1] = 4;
         buffer.buffer_sub_data(1, &[4u8]);

--- a/src/gfx/gl_object/shader_program.rs
+++ b/src/gfx/gl_object/shader_program.rs
@@ -245,20 +245,10 @@ pub mod shader_source
 #[cfg(test)]
 mod tests
 {
-    use wasm_bindgen_test::*;
-    wasm_bindgen_test_configure!(run_in_browser);
-    use wasm_bindgen::
-    {
-        prelude::*,
-        JsCast,
-    };
-    use web_sys::*;
+    inject_wasm_test_boilerplate!();
+
     use crate::gfx::
     {
-        Context,
-        GfxError,
-        GlError,
-        gl_get_errors,
         gl_object::
         {
             shader_program::
@@ -268,21 +258,6 @@ mod tests
                 },
         },
     };
-
-    fn get_context() -> Context
-    {
-        let window: Window = window().expect("window context");
-        let document: Document = window.document().expect("document context");
-
-        let canvas =
-            {
-                let elem = document.create_element("CANVAS").expect("new canvas element");
-                elem.set_id("canvas");
-                document.body().expect("document body").append_child(&elem).expect("canvas added to body");
-                elem.dyn_into::<HtmlCanvasElement>().expect("cast canvas element")
-            };
-        crate::gfx::new_context(&canvas).expect("context")
-    }
 
     fn get_shader_program() -> (Context, ShaderProgram)
     {

--- a/src/gfx/gl_object/shader_program.rs
+++ b/src/gfx/gl_object/shader_program.rs
@@ -258,6 +258,7 @@ mod tests
                 },
         },
     };
+    use crate::gfx::gl_object::traits::Bindable;
 
     fn get_shader_program() -> (Context, ShaderProgram)
     {
@@ -267,6 +268,7 @@ mod tests
             Some(BASIC_VERT.to_string()),
             Some(BASIC_FRAG.to_string())
         ).expect("shader program");
+        shader_program.bind_internal();
         (context, shader_program)
     }
 

--- a/src/gfx/gl_object/shader_program.rs
+++ b/src/gfx/gl_object/shader_program.rs
@@ -241,3 +241,87 @@ pub mod shader_source
     pub const TEXTURE_VERT: &'static str = shader_source!("shaders/texture_vert.glsl");
     pub const TEXTURE_FRAG: &'static str = shader_source!("shaders/texture_frag.glsl");
 }
+
+#[cfg(test)]
+mod tests
+{
+    use wasm_bindgen_test::*;
+    wasm_bindgen_test_configure!(run_in_browser);
+    use wasm_bindgen::
+    {
+        prelude::*,
+        JsCast,
+    };
+    use web_sys::*;
+    use crate::gfx::
+    {
+        Context,
+        GfxError,
+        GlError,
+        gl_get_errors,
+        gl_object::
+        {
+            shader_program::
+                {
+                    ShaderProgram,
+                    shader_source::{BASIC_VERT, BASIC_FRAG}
+                },
+        },
+    };
+
+    fn get_context() -> Context
+    {
+        let window: Window = window().expect("window context");
+        let document: Document = window.document().expect("document context");
+
+        let canvas =
+            {
+                let elem = document.create_element("CANVAS").expect("new canvas element");
+                elem.set_id("canvas");
+                document.body().expect("document body").append_child(&elem).expect("canvas added to body");
+                elem.dyn_into::<HtmlCanvasElement>().expect("cast canvas element")
+            };
+        crate::gfx::new_context(&canvas).expect("context")
+    }
+
+    fn get_shader_program() -> (Context, ShaderProgram)
+    {
+        let context = get_context();
+        let mut shader_program = ShaderProgram::new(
+            &context,
+            Some(BASIC_VERT.to_string()),
+            Some(BASIC_FRAG.to_string())
+        ).expect("shader program");
+        (context, shader_program)
+    }
+
+    #[wasm_bindgen_test]
+    fn test_creation()
+    {
+        let (context, shader_program) = get_shader_program();
+        assert_eq!(GfxError::GlErrors(vec![GlError::NoError]), gl_get_errors(&context));
+    }
+
+    // TODO: Custom test shader so that these tests can pass
+    //       Or would using existing shaders be could so the
+    //       shaders themselves can be tested too?
+    #[wasm_bindgen_test]
+    fn test_block_bindings()
+    {
+        let (context, mut shader_program) = get_shader_program();
+
+        // TODO:
+        //shader_program.add_uniform_block_binding("fake_block", 0).unwrap();
+        //assert_eq!(shader_program.block_bindings[0], Some(String::from("fake_block")))
+    }
+
+    #[wasm_bindgen_test]
+    fn test_set_uniform()
+    {
+        let (context, mut shader_program) = get_shader_program();
+
+        // TODO:
+        //shader_program.set_uniform_i32("fake_uniform", &[0]).unwrap();
+        //assert_eq!(GfxError::GlErrors(vec![GlError::NoError]), gl_get_errors(&context));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ use std::
 #[macro_use]
 mod redeclare;
 #[macro_use]
+mod test_util;
+#[macro_use]
 extern crate memoffset;
 
 mod gfx;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ fn log_s(s: String)
 }
 
 #[wasm_bindgen(start)]
-pub fn main() -> Result<(), JsValue>
+pub fn start_visualization() -> Result<(), JsValue>
 {
     #[cfg(feature="debug")]
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,36 @@
+macro_rules! inject_wasm_test_boilerplate
+{
+    () =>
+    {
+        use wasm_bindgen_test::*;
+        wasm_bindgen_test_configure!(run_in_browser);
+        use wasm_bindgen::
+        {
+            prelude::*,
+            JsCast,
+        };
+        use web_sys::*;
+        use crate::gfx::
+        {
+            Context,
+            GfxError,
+            GlError,
+            gl_get_errors,
+        };
+
+        fn get_context() -> Context
+        {
+            let window: Window = window().expect("window context");
+            let document: Document = window.document().expect("document context");
+
+            let canvas =
+                {
+                    let elem = document.create_element("CANVAS").expect("new canvas element");
+                    elem.set_id("canvas");
+                    document.body().expect("document body").append_child(&elem).expect("canvas added to body");
+                    elem.dyn_into::<HtmlCanvasElement>().expect("cast canvas element")
+                };
+            crate::gfx::new_context(&canvas).expect("context")
+        }
+    }
+}

--- a/wasmtest.py
+++ b/wasmtest.py
@@ -1,4 +1,4 @@
 import os
 
-os.system("wasm-pack test --firefox")
+os.system("wasm-pack test --firefox --chrome --safari")
 

--- a/wasmtest.py
+++ b/wasmtest.py
@@ -1,0 +1,4 @@
+import os
+
+os.system("wasm-pack test --firefox")
+


### PR DESCRIPTION
Basic framework/layout for WASM tests has been created. The `inject_wasm_test_boilerplate!()` macro gets rid of the boilerplate code across different test modules. From here on is just implementing tests for individual systems; the "how to do this" has been (hopefully) figured out. There are currently some basic tests for buffers and some skeleton test functions for ShaderProgram.

Closes #25 