### PR TITLE
Fix RefMut compiler related bug

### DIFF
--- a/src/gfx/render_loop.rs
+++ b/src/gfx/render_loop.rs
@@ -108,7 +108,7 @@ impl RenderLoop
                         // Update context
                         *context = new_context(&canvas).unwrap();
 
-                        (context_config.borrow_mut())(&context);
+                        (&mut *context_config.borrow_mut())(&context);
 
                         // Recreate and reload all given GlObjects with new context
                         globject_manager.borrow_mut().reload_objects(&context);


### PR DESCRIPTION
This fixes a compilation error from a compiler bug where if `&mut *` isn't specifically denoted, then RefMut won't dereference into mutable data

This resolves #50 