### PR TITLE
Fix for canvas sizing bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ features = [
     'XmlHttpRequest',
     'XmlHttpRequestResponseType',
     'ProgressEvent',
+    'UiEvent',
+    'DomRect',
+
 
     # WebGL stuff
     'WebGl2RenderingContext',

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,12 +204,16 @@ fn start(canvas_id: String, _resource_dir: String, resource_manager: Rc<RefCell<
     let canvas_size: (u32, u32) = (canvas.width(), canvas.height());
 
     let context = new_context(&canvas)?;
-    let context_config_func = move |context: &Context|
+    let context_config_func =
         {
-            context.viewport(0, 0, canvas_size.0 as i32, canvas_size.1 as i32);
-            context.pixel_storei(Context::UNPACK_ALIGNMENT, 1);
-            context.enable(Context::CULL_FACE);
-            context.enable(Context::DEPTH_TEST);
+            let canvas = canvas.clone();
+            move |context: &Context|
+                {
+                    context.viewport(0, 0, canvas.width() as i32, canvas.height() as i32);
+                    context.pixel_storei(Context::UNPACK_ALIGNMENT, 1);
+                    context.enable(Context::CULL_FACE);
+                    context.enable(Context::DEPTH_TEST);
+                }
         };
     context_config_func(&context);
 

--- a/testsite.html
+++ b/testsite.html
@@ -24,38 +24,8 @@
                 ext.loseContext();
                 setTimeout(() => ext.restoreContext(), 1000);
             }
-            // Function to assign width and height HTML attributes to canvas since it isn't done automatically
-            function setCanvasWidthHeight()
-            {
-                let canvas = document.getElementById("canvas");
-                let rect = canvas.getBoundingClientRect();
-                canvas.width = rect.width;
-                canvas.height = rect.height;
-            }
-            window.onresize = () =>
-            {
-                // Update the width and height attributes of the canvas
-                setCanvasWidthHeight();
-
-                // Set the WebGL viewport to be a 16:9 resolution close to the dimensions of the canvas to prevent
-                // distortion
-                let canvas = document.getElementById("canvas");
-                let context = canvas.getContext("webgl2");
-                let width = canvas.width;
-                let height = canvas.height;
-                while(Math.abs((width / height) - (16.0/9.0)) > 0.005)
-                {
-                    let x = Math.floor(Math.max(width / 16.0, height / 9.0));
-                    width = x * 16;
-                    height = x * 9;
-                }
-                context.viewport(0, 0, width, height);
-            };
-
             window.onload = () =>
             {
-                setCanvasWidthHeight();
-
                 const { init_visualization } = wasm_bindgen;
                 async function run()
                 {

--- a/testsite.html
+++ b/testsite.html
@@ -24,17 +24,50 @@
                 ext.loseContext();
                 setTimeout(() => ext.restoreContext(), 1000);
             }
-            const { init_visualization } = wasm_bindgen;
-            async function run()
+            // Function to assign width and height HTML attributes to canvas since it isn't done automatically
+            function setCanvasWidthHeight()
             {
-                await wasm_bindgen('./build/swarm_website_visualization_bg.wasm');
-                init_visualization("canvas", "/resources");
+                let canvas = document.getElementById("canvas");
+                let rect = canvas.getBoundingClientRect();
+                canvas.width = rect.width;
+                canvas.height = rect.height;
             }
-            run();
+            window.onresize = () =>
+            {
+                // Update the width and height attributes of the canvas
+                setCanvasWidthHeight();
+
+                // Set the WebGL viewport to be a 16:9 resolution close to the dimensions of the canvas to prevent
+                // distortion
+                let canvas = document.getElementById("canvas");
+                let context = canvas.getContext("webgl2");
+                let width = canvas.width;
+                let height = canvas.height;
+                while(Math.abs((width / height) - (16.0/9.0)) > 0.005)
+                {
+                    let x = Math.floor(Math.max(width / 16.0, height / 9.0));
+                    width = x * 16;
+                    height = x * 9;
+                }
+                context.viewport(0, 0, width, height);
+            };
+
+            window.onload = () =>
+            {
+                setCanvasWidthHeight();
+
+                const { init_visualization } = wasm_bindgen;
+                async function run()
+                {
+                    await wasm_bindgen('./build/swarm_website_visualization_bg.wasm');
+                    init_visualization("canvas", "/resources");
+                }
+                run();
+            };
         </script>
     </head>
     <body>
         <!--tabindex="1" allows the canvas to be focusable-->
-        <canvas id="canvas" tabindex="1" width="1280" height="720" style=""/>
+        <canvas id="canvas" tabindex="1" style="width:100%;"/>
     </body>
 </html>


### PR DESCRIPTION
Resolves #58. 

Please run with the test server and make sure that the canvas is sized properly on start and when the browser window is resized. The image shouldn't become pixelated and/or distorted in any way. 