### PR TITLE
Async resource loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ twox-hash = "1.5.0"
 memoffset = "0.5"
 tobj = "2.0"
 float-cmp = "0.8.0"
+wasm-bindgen-futures = "0.4.18"
 
 [dependencies.web-sys]
 version = "0.3"
@@ -48,6 +49,13 @@ features = [
     'XmlHttpRequestResponseType',
     'ProgressEvent',
 
+    # Fetch API
+    'Headers',
+    'Request',
+    'RequestInit',
+    'RequestMode',
+    'Response',
+
     # WebGL stuff
     'WebGl2RenderingContext',
     "WebGlContextEvent",
@@ -63,7 +71,6 @@ features = [
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
-wasm-bindgen-futures = "0.4.18"
 
 [profile.release]
 lto=true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ memoffset = "0.5"
 tobj = "2.0"
 float-cmp = "0.8.0"
 wasm-bindgen-futures = "0.4.18"
+futures = "0.3.13"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/src/resource/async_loader.rs
+++ b/src/resource/async_loader.rs
@@ -4,6 +4,32 @@ use wasm_bindgen::
     JsCast,
 };
 use wasm_bindgen_futures::JsFuture;
+use web_sys::
+{
+    Request,
+    RequestInit,
+    RequestMode,
+    Response,
+};
+use js_sys::
+{
+    ArrayBuffer,
+    Uint8Array,
+};
+
+pub enum AsyncResourceError
+{
+    JsValueErr(JsValue),
+    StrErr(&'static str),
+}
+impl From<JsValue> for AsyncResourceError
+{
+    fn from(js_val: JsValue) -> Self { AsyncResourceError::JsValueErr(js_val) }
+}
+impl From<&'static str> for AsyncResourceError
+{
+    fn from(s: &'static str) -> Self { AsyncResourceError::StrErr(s) }
+}
 
 pub struct AsyncResourceLoader
 {
@@ -12,8 +38,28 @@ pub struct AsyncResourceLoader
 
 impl AsyncResourceLoader
 {
-    pub fn load(resource: &str) -> Result<>
+    pub async fn load(resource_url: &str) -> Result<Vec<u8>, AsyncResourceError>
     {
+        let mut req_opts = RequestInit::new();
+        req_opts.method("GET");
+        req_opts.mode(RequestMode::Cors);
 
+/*        let request = Request::new_with_str_and_init(&resource_url, &req_opts)
+            .expect("New fetch API request object");*/
+        let request = Request::new_with_str_and_init(&resource_url, req_opts)
+            .expect("New Request object");
+
+        let window = web_sys::window().expect("Window context");
+        let resp_value = JsFuture::from(window.fetch_with_request(&request)).await
+            .expect("Promise resolved");
+
+        let resp: Response = resp_value.dyn_into()
+            .or(Err("Response is not 'Request' type"))?;
+        // TODO: Check for error
+
+        let body_buffer: ArrayBuffer = JsFuture::from(resp.array_buffer()?).await?.into();
+        let bytes_buffer = Uint8Array::new(&body_buffer);
+
+        Ok(bytes_buffer.to_vec())
     }
 }

--- a/src/resource/async_loader.rs
+++ b/src/resource/async_loader.rs
@@ -17,6 +17,7 @@ use js_sys::
     Uint8Array,
 };
 
+#[derive(Debug)]
 pub enum AsyncResourceError
 {
     JsValueErr(JsValue),
@@ -31,35 +32,57 @@ impl From<&'static str> for AsyncResourceError
     fn from(s: &'static str) -> Self { AsyncResourceError::StrErr(s) }
 }
 
-pub struct AsyncResourceLoader
+/// Download the contents from `resource_url` and load it into memory as a byte vector
+pub async fn load<S: AsRef<str>>(resource_url: S) -> Result<Vec<u8>, AsyncResourceError>
 {
+    // Set the request as a CORS GET request
+    let mut req_opts = RequestInit::new();
+    req_opts.method("GET");
+    // TODO: Should the request be CORS?
+    req_opts.mode(RequestMode::Cors);
 
-}
+    // Create the request
+    let request = Request::new_with_str_and_init(resource_url.as_ref(), &req_opts)
+        .expect("New fetch API request object");
+    let window = web_sys::window().expect("Window context");
+    // Create a Future out of the fetch request
+    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await
+        .expect("Promise resolved");
 
-impl AsyncResourceLoader
-{
-    pub async fn load(resource_url: &str) -> Result<Vec<u8>, AsyncResourceError>
+    let resp: Response = resp_value.dyn_into()
+        .or(Err("Response is not 'Request' type"))?;
+
+    if resp.ok()
     {
-        let mut req_opts = RequestInit::new();
-        req_opts.method("GET");
-        req_opts.mode(RequestMode::Cors);
-
-/*        let request = Request::new_with_str_and_init(&resource_url, &req_opts)
-            .expect("New fetch API request object");*/
-        let request = Request::new_with_str_and_init(&resource_url, req_opts)
-            .expect("New Request object");
-
-        let window = web_sys::window().expect("Window context");
-        let resp_value = JsFuture::from(window.fetch_with_request(&request)).await
-            .expect("Promise resolved");
-
-        let resp: Response = resp_value.dyn_into()
-            .or(Err("Response is not 'Request' type"))?;
-        // TODO: Check for error
-
+        // Get the response body as a byte buffer
         let body_buffer: ArrayBuffer = JsFuture::from(resp.array_buffer()?).await?.into();
         let bytes_buffer = Uint8Array::new(&body_buffer);
 
         Ok(bytes_buffer.to_vec())
     }
+    else
+    {
+        Err(AsyncResourceError::StrErr("Failed to fetch resource"))
+    }
+}
+
+/// Asynchronously download the resource located at each of the `resource_urls`
+/// The returned `Vec` contains either the resource as a byte buffer, or an error that
+/// occurred while downloading the resource. This `Vec` is in the same order as the
+/// `resource_urls`. i.e. index 0 of the return `Vec` is the result for index 0 of
+/// `resource_urls`
+pub async fn load_multiple<S: ToString>(resource_urls: &Vec<S>)
+                                        -> Vec<Result<Vec<u8>, AsyncResourceError>>
+{
+    let mut tasks = Vec::with_capacity(resource_urls.len());
+
+    for url in resource_urls
+    {
+        let url = url.to_string();
+        tasks.push(async move {
+            self::load(&url).await
+        });
+    }
+
+    futures::future::join_all(tasks).await
 }

--- a/src/resource/async_loader.rs
+++ b/src/resource/async_loader.rs
@@ -1,0 +1,19 @@
+use wasm_bindgen::
+{
+    prelude::*,
+    JsCast,
+};
+use wasm_bindgen_futures::JsFuture;
+
+pub struct AsyncResourceLoader
+{
+
+}
+
+impl AsyncResourceLoader
+{
+    pub fn load(resource: &str) -> Result<>
+    {
+
+    }
+}

--- a/src/resource/loader.rs
+++ b/src/resource/loader.rs
@@ -77,6 +77,7 @@ pub struct ResourceLoader
 impl ResourceLoader
 {
     /// Create empty resource loader
+    #[allow(dead_code)]
     pub fn new() -> Self
     {
         ResourceLoader

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -1,3 +1,3 @@
 pub mod manager;
 pub mod loader;
-mod async_loader;
+pub mod async_loader;

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -1,2 +1,3 @@
 pub mod manager;
 pub mod loader;
+mod async_loader;


### PR DESCRIPTION
closes #46 
- This adds the completed async loader `load` and `load_multiple` functions, for loading a single resourcing or multiple concurrently