### PR TITLE
Replace regular Strings in parameters

### DIFF
--- a/src/gfx/renderer/renderer.rs
+++ b/src/gfx/renderer/renderer.rs
@@ -48,10 +48,10 @@ impl Renderer
     pub fn new(context: &Context, gl_manager: &mut GlObjectManager, resource_manager: &ResourceManager) -> Result<Renderer, GfxError>
     {
         // Get shader source code and read into string
-        let vert_shader = String::from_utf8(resource_manager.get_by_name(&"texture_vert.glsl".to_string())
+        let vert_shader = String::from_utf8(resource_manager.get_by_name("texture_vert.glsl")
             .ok_or_else(|| GfxError::Other("texture_vert.glsl not available by name in resource manager".to_string()))?.clone())
             .or_else(|err| Err(GfxError::Other(format!("Error reading texture_vert.glsl into string: {}", err.to_string()))))?;
-        let frag_shader = String::from_utf8(resource_manager.get_by_name(&"texture_frag.glsl".to_string()).
+        let frag_shader = String::from_utf8(resource_manager.get_by_name("texture_frag.glsl").
             ok_or_else(|| GfxError::Other("texture_frag.glsl not available by name in resource manager".to_string()))?.clone())
             .or_else(|err| Err(GfxError::Other(format!("Error reading texture_frag.glsl into string: {}", err.to_string()))))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,23 +141,23 @@ pub async fn init_visualization(canvas_id: String, resource_dir: String) -> Resu
         *url = resource_dir.to_owned() + url;
     }
 
-    let urls = resource_urls.iter().map(AsRef::<str>::as_ref).collect();
-    let mut resources = async_loader::load_multiple(&urls).await;
+    //let urls = resource_urls.iter().map(AsRef::<str>::as_ref).collect();
+    let mut resources = async_loader::load_multiple(&resource_urls).await;
 
     resource_manager.insert_with_name(
-        "robot.obj".to_string(),
+        "robot.obj",
         resources.remove(0).expect("robot.obj"));
     resource_manager.insert_with_name(
-        "room.obj".to_string(),
+        "room.obj",
         resources.remove(0).expect("room.obj"));
     resource_manager.insert_with_name(
-        "tex_atlas.pbm".to_string(),
+        "tex_atlas.pbm",
         resources.remove(0).expect("tex_atlas.pbm"));
     resource_manager.insert_with_name(
-        "texture_vert.glsl".to_string(),
+        "texture_vert.glsl",
         resources.remove(0).expect("texture_vert.glsl"));
     resource_manager.insert_with_name(
-        "texture_frag.glsl".to_string(),
+        "texture_frag.glsl",
         resources.remove(0).expect("texture_frag.glsl"));
 
     start(canvas_id, resource_dir, Rc::new(RefCell::new(resource_manager)))
@@ -222,9 +222,9 @@ fn start(canvas_id: String, _resource_dir: String, resource_manager: Rc<RefCell<
         };
     context_config_func(&context);
 
-    let robot_obj = resource_manager.borrow().get_by_name(&"robot.obj".to_string()).expect("robot obj resource").clone();
+    let robot_obj = resource_manager.borrow().get_by_name("robot.obj").expect("robot obj resource").clone();
     let robot_mesh = Mesh::from_reader(&*robot_obj).expect("robot mesh");
-    let room_obj = resource_manager.borrow().get_by_name(&"room.obj".to_string()).expect("room obj resource").clone();
+    let room_obj = resource_manager.borrow().get_by_name("room.obj").expect("room obj resource").clone();
     let room_mesh = Mesh::from_reader(&*room_obj).expect("room mesh");
 
     // Setup object manager
@@ -233,7 +233,7 @@ fn start(canvas_id: String, _resource_dir: String, resource_manager: Rc<RefCell<
 
 
     // Texture atlas
-    let tex_atlas_pbm = resource_manager.borrow().get_by_name(&"tex_atlas.pbm".to_string()).expect("texture atlas").clone();
+    let tex_atlas_pbm = resource_manager.borrow().get_by_name("tex_atlas.pbm").expect("texture atlas").clone();
 
     let texture_atlas_handle = manager_ref.insert_texture2d(
         Texture2d::new(&context, Texture2dParams

--- a/src/resource/manager.rs
+++ b/src/resource/manager.rs
@@ -34,10 +34,10 @@ impl ResourceManager
     ///
     /// If `name` already exists, it overwrites the existing resource
     #[allow(dead_code)]
-    pub fn insert_with_name(&mut self, name: String, resource: Vec<u8>) -> ResourceHandle
+    pub fn insert_with_name<S: Into<String>>(&mut self, name: S, resource: Vec<u8>) -> ResourceHandle
     {
         let handle = self.insert(resource);
-        if let Some(old) = self.handle_map.insert(name, handle)
+        if let Some(old) = self.handle_map.insert(name.into(), handle)
         {
             self.resources.remove(old);
         }
@@ -51,14 +51,14 @@ impl ResourceManager
     }
 
     #[allow(dead_code)]
-    pub fn get_by_name(&self, name: &String) -> Option<&Vec<u8>>
+    pub fn get_by_name(&self, name: &str) -> Option<&Vec<u8>>
     {
         let handle = *self.handle_map.get(name)?;
         self.get(handle)
     }
 
     #[allow(dead_code)]
-    pub fn get_named_handle(&self, name: &String) -> Option<ResourceHandle>
+    pub fn get_named_handle(&self, name: &str) -> Option<ResourceHandle>
     {
         self.handle_map.get(name).copied()
     }
@@ -70,7 +70,7 @@ impl ResourceManager
     }
 
     #[allow(dead_code)]
-    pub fn remove_by_name(&mut self, name: &String) -> Option<Vec<u8>>
+    pub fn remove_by_name(&mut self, name: &str) -> Option<Vec<u8>>
     {
         let handle = self.handle_map.remove(name)?;
         self.remove(handle)
@@ -104,8 +104,8 @@ mod tests
 
         assert_eq!(manager.get(r1).unwrap(), &vec![0u8, 1u8]);
         assert_eq!(manager.get(r2).unwrap(), &vec![2u8, 3u8]);
-        assert_eq!(manager.get_by_name(&"name1".to_string()), Some(&vec![0u8, 1u8]));
-        assert_eq!(manager.get_by_name(&"name2".to_string()), Some(&vec![2u8, 3u8]));
+        assert_eq!(manager.get_by_name("name1"), Some(&vec![0u8, 1u8]));
+        assert_eq!(manager.get_by_name("name2"), Some(&vec![2u8, 3u8]));
         assert_eq!(manager.get_named_handle(&"name1".to_string()), Some(r1));
         assert_eq!(manager.get_named_handle(&"name2".to_string()), Some(r2));
         assert_eq!(manager.remove_by_name(&"name1".to_string()), Some(vec![0u8, 1u8]));


### PR DESCRIPTION
closes #64 
- This replaces regular `String` and `&str` parameters with `AsRef`, `Into`, and `ToString` traits where appropriate and applicable